### PR TITLE
Fixing port when default configuration is selected.

### DIFF
--- a/cmd/print.go
+++ b/cmd/print.go
@@ -24,7 +24,7 @@ func isJSONString(s string) bool {
 	return json.Unmarshal([]byte(s), &js) == nil
 }
 
-func CheckForEmptyArgsAndExit(args []string, message string){
+func CheckForEmptyArgsAndExit(args []string, message string) {
 	if len(args) == 0 {
 		fmt.Println(message)
 		os.Exit(1)
@@ -53,18 +53,12 @@ func PrintPods(podList v1.PodList) {
 }
 
 func PrintPrettyHttpResponse(resp *http.Response, err error) {
-	if err != nil {
-		fmt.Printf("[*] Failed to run HTTP request with error: %s\n", err)
-		os.Exit(1)
-	}
-
 	bodyBytes, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		log.Fatal(err)
 	}
 
 	bodyString := string(bodyBytes)
-
 	if resp.StatusCode == http.StatusOK {
 
 		// TODO: consider changing it by checking the first and the last byte "{..}".

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -4,11 +4,11 @@ import (
 	"fmt"
 	"github.com/spf13/cobra"
 	"io/ioutil"
+	restclient "k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 	"kubeletctl/pkg/api"
 	"log"
 	"net/url"
-	restclient "k8s.io/client-go/rest"
 	"os"
 )
 
@@ -164,7 +164,8 @@ func initConfig() {
 				&clientcmd.ConfigOverrides{},
 			)
 			config, err = kubeConfig.ClientConfig()
-			if err != nil && len(os.Getenv(clientcmd.RecommendedConfigPathEnvVar)) > 0 {
+			// TODO: should fail when YAML is wrong, like with ":"
+			if err != nil { //&& len(os.Getenv(clientcmd.RecommendedConfigPathEnvVar)) > 0 {
 				fmt.Fprintln(os.Stderr, "[*] There is a problem with the file in KUBECONFIG environment variable\n[*] You can ignore it by modifying the KUBECONFIG environment variable, file \"~/.kube/config\" or use the \"-i\" switch")
 				panic(err.Error())
 			}
@@ -175,9 +176,6 @@ func initConfig() {
 		hostUrl, err := url.Parse(config.Host)
 		if err != nil {
 			panic(err.Error())
-		}
-		if PortFlag == "" {
-			PortFlag = hostUrl.Port()
 		}
 		if ServerIpAddressFlag == "" {
 			ServerIpAddressFlag = hostUrl.Hostname()


### PR DESCRIPTION
Fixing the print with 'http error' in 'PrintPrettyHttpResponse' function.

### Desired Outcome

Fixing port when default configuration is selected.
Fixing the print with 'http error' in 'PrintPrettyHttpResponse' function.

### Implemented Changes

Fixing the port issue when default kube config file is selected.

Fixing port when default configuration is selected.
Fixing the print with 'http error' in 'PrintPrettyHttpResponse' function.

### Connected Issue/Story

Resolves #[relevant GitHub issue(s), e.g. 76]

CyberArk internal issue link: [insert issue ID]()

### Definition of Done
*At least 1 todo must be completed in the sections below for the PR to be
merged.*

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [ ] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]()
- [ ] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [ ] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [ ] There are no security aspects to these changes 
