### PR TITLE
Added Darwin/arm64 binary build support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ all:
 	go mod vendor;
 	go fmt ./...;
 	mkdir -p build;
-	GOFLAGS=-mod=vendor gox -ldflags "-s -w" --osarch="linux/386" --osarch="linux/amd64" --osarch="windows/386" --osarch="windows/amd64" --osarch="darwin/386" --osarch="darwin/amd64" -output "build/kubeletctl_{{.OS}}_{{.Arch}}"
+	GOFLAGS=-mod=vendor gox -ldflags "-s -w" --osarch="linux/386" --osarch="linux/amd64" --osarch="windows/386" --osarch="windows/amd64" --osarch="darwin/386" --osarch="darwin/amd64" --osarch="darwin/arm64" -output "build/kubeletctl_{{.OS}}_{{.Arch}}"
 
 docker:
 	docker build . -t kubeletctl:latest


### PR DESCRIPTION
this will let Apple silicon users (M1/M2/M3 Macbooks) use kubeletctl seamlessly without any build issues

### Connected Issue/Story

Resolves #37 

### Build
<img width="2006" alt="image" src="https://github.com/cyberark/kubeletctl/assets/30806882/bfa301ce-0940-4e8a-94da-69b707480a10">

#### Working
<img width="1472" alt="image" src="https://github.com/cyberark/kubeletctl/assets/30806882/ddc4ccc2-bc85-4e39-9040-b5551dbcbaa9">


