### PR TITLE
Adding linux/arm64 support and Update Makefile 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ all:
 	go mod vendor;
 	go fmt ./...;
 	mkdir -p build;
-	GOFLAGS=-mod=vendor gox -ldflags "-s -w" --osarch="linux/386" --osarch="linux/amd64" --osarch="windows/386" --osarch="windows/amd64" --osarch="darwin/386" --osarch="darwin/amd64" --osarch="darwin/arm64" -output "build/kubeletctl_{{.OS}}_{{.Arch}}"
+	GOFLAGS=-mod=vendor gox -ldflags "-s -w" --osarch="linux/386" --osarch="linux/amd64" --osarch="linux/arm64" --osarch="windows/386" --osarch="windows/amd64" --osarch="darwin/386" --osarch="darwin/amd64" --osarch="darwin/arm64" -output "build/kubeletctl_{{.OS}}_{{.Arch}}"
 
 docker:
 	docker build . -t kubeletctl:latest

--- a/Makefile
+++ b/Makefile
@@ -3,9 +3,13 @@
 all: linux-arm64
 
 linux-arm64:
+	@echo "Running go mod vendor"
 	go mod vendor
+	@echo "Running go fmt"
 	go fmt ./...
+	@echo "Creating build directory"
 	mkdir -p build
+	@echo "Running gox for linux/arm64"
 	gox -verbose -osarch="linux/arm64" -output="build/kubeletctl_{{.OS}}_{{.Arch}}"
 
 docker:

--- a/Makefile
+++ b/Makefile
@@ -1,18 +1,20 @@
-.PHONY: all linux-arm64 clean docker docker-release
+.PHONY: all
 
-all: linux-arm64
-
-linux-arm64:
-	go mod vendor
-	go fmt ./...
-	mkdir -p build
-	GOARCH=arm64 GOOS=linux go build -v -o build/kubeletctl_linux_arm64
+all:
+	go mod vendor;
+	go fmt ./...;
+	mkdir -p build;
+	GOARCH=386 GOOS=linux go build -v -o build/kubeletctl_linux_386;
+	GOARCH=amd64 GOOS=linux go build -v -o build/kubeletctl_linux_amd64;
+	GOARCH=arm64 GOOS=linux go build -v -o build/kubeletctl_linux_arm64;
+	GOARCH=386 GOOS=windows go build -v -o build/kubeletctl_windows_386.exe;
+	GOARCH=amd64 GOOS=windows go build -v -o build/kubeletctl_windows_amd64.exe;
+	GOARCH=386 GOOS=darwin go build -v -o build/kubeletctl_darwin_386;
+	GOARCH=amd64 GOOS=darwin go build -v -o build/kubeletctl_darwin_amd64;
+	GOARCH=arm64 GOOS=darwin go build -v -o build/kubeletctl_darwin_arm64;
 
 docker:
 	docker build . -t kubeletctl:latest
 
 docker-release:
-	docker build -t kubeletctl:release -f Dockerfile.latest
-
-clean:
-	rm -rf build
+	docker build -t kubeletctl:release -f Dockerfile.latest .

--- a/Makefile
+++ b/Makefile
@@ -1,19 +1,18 @@
-.PHONY: all linux-arm64 docker docker-release
+.PHONY: all linux-arm64 clean docker docker-release
 
-all:
-	go mod vendor
-	go fmt ./...
-	mkdir -p build
-	GOFLAGS=-mod=vendor gox -ldflags "-s -w" --osarch="linux/386" --osarch="linux/amd64" --osarch="linux/arm64" --osarch="windows/386" --osarch="windows/amd64" --osarch="darwin/386" --osarch="darwin/amd64" --osarch="darwin/arm64" -output "build/kubeletctl_{{.OS}}_{{.Arch}}"
+all: linux-arm64
 
 linux-arm64:
 	go mod vendor
 	go fmt ./...
 	mkdir -p build
-	GOFLAGS=-mod=vendor gox -ldflags "-s -w" --osarch="linux/arm64" -output "build/kubeletctl_linux_arm64"
+	gox -verbose -osarch="linux/arm64" -output="build/kubeletctl_{{.OS}}_{{.Arch}}"
 
 docker:
 	docker build . -t kubeletctl:latest
 
 docker-release:
-	docker build -t kubeletctl:release -f Dockerfile.latest .
+	docker build -t kubeletctl:release -f Dockerfile.latest
+
+clean:
+	rm -rf build

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ all:
 	GOARCH=arm64 GOOS=linux go build -v -o $(BUILD_DIR)/kubeletctl_linux_arm64;
 	GOARCH=386 GOOS=windows go build -v -o $(BUILD_DIR)/kubeletctl_windows_386.exe;
 	GOARCH=amd64 GOOS=windows go build -v -o $(BUILD_DIR)/kubeletctl_windows_amd64.exe;
-	# GOARCH=386 GOOS=darwin go build -v -o $(BUILD_DIR)/kubeletctl_darwin_386; # Commented as Darwin 386 builds may not be supported
+# GOARCH=386 GOOS=darwin go build -v -o $(BUILD_DIR)/kubeletctl_darwin_386;
 	GOARCH=amd64 GOOS=darwin go build -v -o $(BUILD_DIR)/kubeletctl_darwin_amd64;
 	GOARCH=arm64 GOOS=darwin go build -v -o $(BUILD_DIR)/kubeletctl_darwin_arm64;
 	
@@ -36,7 +36,7 @@ windows_amd64:
 
 darwin: darwin_amd64 darwin_arm64
 
-# darwin_386: # Commented out as macOS 386 builds may not be applicable
+# darwin_386:
 # 	GOARCH=386 GOOS=darwin go build -v -o $(BUILD_DIR)/kubeletctl_darwin_386;
 
 darwin_amd64:

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all
+.PHONY: all clean linux windows darwin docker docker-release
 
 all:
 	go mod vendor;
@@ -12,9 +12,42 @@ all:
 	GOARCH=386 GOOS=darwin go build -v -o build/kubeletctl_darwin_386;
 	GOARCH=amd64 GOOS=darwin go build -v -o build/kubeletctl_darwin_amd64;
 	GOARCH=arm64 GOOS=darwin go build -v -o build/kubeletctl_darwin_arm64;
+	
+linux: linux_386 linux_amd64 linux_arm64
+
+linux_386:
+	GOARCH=386 GOOS=linux go build -v -o build/kubeletctl_linux_386;
+
+linux_amd64:
+	GOARCH=amd64 GOOS=linux go build -v -o build/kubeletctl_linux_amd64;
+
+linux_arm64:
+	GOARCH=arm64 GOOS=linux go build -v -o build/kubeletctl_linux_arm64;
+
+windows: windows_386 windows_amd64
+
+windows_386:
+	GOARCH=386 GOOS=windows go build -v -o build/kubeletctl_windows_386.exe;
+
+windows_amd64:
+	GOARCH=amd64 GOOS=windows go build -v -o build/kubeletctl_windows_amd64.exe;
+
+darwin: darwin_386 darwin_amd64 darwin_arm64
+
+darwin_386:
+	GOARCH=386 GOOS=darwin go build -v -o build/kubeletctl_darwin_386;
+
+darwin_amd64:
+	GOARCH=amd64 GOOS=darwin go build -v -o build/kubeletctl_darwin_amd64;
+
+darwin_arm64:
+	GOARCH=arm64 GOOS=darwin go build -v -o build/kubeletctl_darwin_arm64;
 
 docker:
 	docker build . -t kubeletctl:latest
 
 docker-release:
 	docker build -t kubeletctl:release -f Dockerfile.latest .
+	
+clean:
+	rm -rf build/

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,16 @@
-.PHONY: all
+.PHONY: all linux-arm64 docker docker-release
 
 all:
-	go mod vendor;
-	go fmt ./...;
-	mkdir -p build;
+	go mod vendor
+	go fmt ./...
+	mkdir -p build
 	GOFLAGS=-mod=vendor gox -ldflags "-s -w" --osarch="linux/386" --osarch="linux/amd64" --osarch="linux/arm64" --osarch="windows/386" --osarch="windows/amd64" --osarch="darwin/386" --osarch="darwin/amd64" --osarch="darwin/arm64" -output "build/kubeletctl_{{.OS}}_{{.Arch}}"
+
+linux-arm64:
+	go mod vendor
+	go fmt ./...
+	mkdir -p build
+	GOFLAGS=-mod=vendor gox -ldflags "-s -w" --osarch="linux/arm64" -output "build/kubeletctl_linux_arm64"
 
 docker:
 	docker build . -t kubeletctl:latest

--- a/Makefile
+++ b/Makefile
@@ -1,53 +1,55 @@
 .PHONY: all clean linux windows darwin docker docker-release
 
+BUILD_DIR=build
+
 all:
 	go mod vendor;
 	go fmt ./...;
-	mkdir -p build;
-	GOARCH=386 GOOS=linux go build -v -o build/kubeletctl_linux_386;
-	GOARCH=amd64 GOOS=linux go build -v -o build/kubeletctl_linux_amd64;
-	GOARCH=arm64 GOOS=linux go build -v -o build/kubeletctl_linux_arm64;
-	GOARCH=386 GOOS=windows go build -v -o build/kubeletctl_windows_386.exe;
-	GOARCH=amd64 GOOS=windows go build -v -o build/kubeletctl_windows_amd64.exe;
-	GOARCH=386 GOOS=darwin go build -v -o build/kubeletctl_darwin_386;
-	GOARCH=amd64 GOOS=darwin go build -v -o build/kubeletctl_darwin_amd64;
-	GOARCH=arm64 GOOS=darwin go build -v -o build/kubeletctl_darwin_arm64;
+	mkdir -p $(BUILD_DIR);
+	GOARCH=386 GOOS=linux go build -v -o $(BUILD_DIR)/kubeletctl_linux_386;
+	GOARCH=amd64 GOOS=linux go build -v -o $(BUILD_DIR)/kubeletctl_linux_amd64;
+	GOARCH=arm64 GOOS=linux go build -v -o $(BUILD_DIR)/kubeletctl_linux_arm64;
+	GOARCH=386 GOOS=windows go build -v -o $(BUILD_DIR)/kubeletctl_windows_386.exe;
+	GOARCH=amd64 GOOS=windows go build -v -o $(BUILD_DIR)/kubeletctl_windows_amd64.exe;
+	# GOARCH=386 GOOS=darwin go build -v -o $(BUILD_DIR)/kubeletctl_darwin_386; # Commented as Darwin 386 builds may not be supported
+	GOARCH=amd64 GOOS=darwin go build -v -o $(BUILD_DIR)/kubeletctl_darwin_amd64;
+	GOARCH=arm64 GOOS=darwin go build -v -o $(BUILD_DIR)/kubeletctl_darwin_arm64;
 	
 linux: linux_386 linux_amd64 linux_arm64
 
 linux_386:
-	GOARCH=386 GOOS=linux go build -v -o build/kubeletctl_linux_386;
+	GOARCH=386 GOOS=linux go build -v -o $(BUILD_DIR)/kubeletctl_linux_386;
 
 linux_amd64:
-	GOARCH=amd64 GOOS=linux go build -v -o build/kubeletctl_linux_amd64;
+	GOARCH=amd64 GOOS=linux go build -v -o $(BUILD_DIR)/kubeletctl_linux_amd64;
 
 linux_arm64:
-	GOARCH=arm64 GOOS=linux go build -v -o build/kubeletctl_linux_arm64;
+	GOARCH=arm64 GOOS=linux go build -v -o $(BUILD_DIR)/kubeletctl_linux_arm64;
 
 windows: windows_386 windows_amd64
 
 windows_386:
-	GOARCH=386 GOOS=windows go build -v -o build/kubeletctl_windows_386.exe;
+	GOARCH=386 GOOS=windows go build -v -o $(BUILD_DIR)/kubeletctl_windows_386.exe;
 
 windows_amd64:
-	GOARCH=amd64 GOOS=windows go build -v -o build/kubeletctl_windows_amd64.exe;
+	GOARCH=amd64 GOOS=windows go build -v -o $(BUILD_DIR)/kubeletctl_windows_amd64.exe;
 
-darwin: darwin_386 darwin_amd64 darwin_arm64
+darwin: darwin_amd64 darwin_arm64
 
-darwin_386:
-	GOARCH=386 GOOS=darwin go build -v -o build/kubeletctl_darwin_386;
+# darwin_386: # Commented out as macOS 386 builds may not be applicable
+# 	GOARCH=386 GOOS=darwin go build -v -o $(BUILD_DIR)/kubeletctl_darwin_386;
 
 darwin_amd64:
-	GOARCH=amd64 GOOS=darwin go build -v -o build/kubeletctl_darwin_amd64;
+	GOARCH=amd64 GOOS=darwin go build -v -o $(BUILD_DIR)/kubeletctl_darwin_amd64;
 
 darwin_arm64:
-	GOARCH=arm64 GOOS=darwin go build -v -o build/kubeletctl_darwin_arm64;
+	GOARCH=arm64 GOOS=darwin go build -v -o $(BUILD_DIR)/kubeletctl_darwin_arm64;
 
 docker:
 	docker build . -t kubeletctl:latest
 
 docker-release:
 	docker build -t kubeletctl:release -f Dockerfile.latest .
-	
+
 clean:
-	rm -rf build/
+	rm -rf $(BUILD_DIR)/

--- a/Makefile
+++ b/Makefile
@@ -3,14 +3,10 @@
 all: linux-arm64
 
 linux-arm64:
-	@echo "Running go mod vendor"
 	go mod vendor
-	@echo "Running go fmt"
 	go fmt ./...
-	@echo "Creating build directory"
 	mkdir -p build
-	@echo "Running gox for linux/arm64"
-	gox -verbose -osarch="linux/arm64" -output="build/kubeletctl_{{.OS}}_{{.Arch}}"
+	GOARCH=arm64 GOOS=linux go build -v -o build/kubeletctl_linux_arm64
 
 docker:
 	docker build . -t kubeletctl:latest


### PR DESCRIPTION
Adding Arm64 Support.

In addition - gox library is deprecated so change the build making by using  go command   - GOARCH=arm64 GOOS=linux go build.
Also adding option to a specific build by using  make ___(os)___(arch) for example make windows_amd64 will make a exec for windows with amd64 architecture.

