### PR TITLE
Run Parallel Pods Improvement and Makefile Update

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 BUILD_DIR=build
 
-all: linux	windows darwin
+all: linux windows darwin
 	
 linux: linux_386 linux_amd64 linux_arm64
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all $(PLATFORMS) clean linux windows darwin docker docker-release
+.PHONY: all clean linux windows darwin docker docker-release
 
 BUILD_DIR=build
 

--- a/Makefile
+++ b/Makefile
@@ -1,19 +1,8 @@
-.PHONY: all clean linux windows darwin docker docker-release
+.PHONY: all $(PLATFORMS) clean linux windows darwin docker docker-release
 
 BUILD_DIR=build
 
-all:
-	go mod vendor;
-	go fmt ./...;
-	mkdir -p $(BUILD_DIR);
-	GOARCH=386 GOOS=linux go build -v -o $(BUILD_DIR)/kubeletctl_linux_386;
-	GOARCH=amd64 GOOS=linux go build -v -o $(BUILD_DIR)/kubeletctl_linux_amd64;
-	GOARCH=arm64 GOOS=linux go build -v -o $(BUILD_DIR)/kubeletctl_linux_arm64;
-	GOARCH=386 GOOS=windows go build -v -o $(BUILD_DIR)/kubeletctl_windows_386.exe;
-	GOARCH=amd64 GOOS=windows go build -v -o $(BUILD_DIR)/kubeletctl_windows_amd64.exe;
-# GOARCH=386 GOOS=darwin go build -v -o $(BUILD_DIR)/kubeletctl_darwin_386;
-	GOARCH=amd64 GOOS=darwin go build -v -o $(BUILD_DIR)/kubeletctl_darwin_amd64;
-	GOARCH=arm64 GOOS=darwin go build -v -o $(BUILD_DIR)/kubeletctl_darwin_arm64;
+all: linux	windows darwin
 	
 linux: linux_386 linux_amd64 linux_arm64
 

--- a/pkg/utils/run.go
+++ b/pkg/utils/run.go
@@ -75,7 +75,8 @@ func runParallelCommandsOnPods(runPodsInfo []RunPodInfo, concurrencyLimit int, c
 
 	// keen an index and loop through every Url we will send a request to
 	for i, podInfo := range runPodsInfo {
-
+		localI := i
+		localPodInfo := podInfo
 		// start a go routine with the index and Url in a closure
 		go func(i int, podInfo RunPodInfo) {
 
@@ -108,7 +109,7 @@ func runParallelCommandsOnPods(runPodsInfo []RunPodInfo, concurrencyLimit int, c
 			// another goroutine to start
 			<-semaphoreChan
 
-		}(i, podInfo)
+		}(localI, localPodInfo)
 	}
 
 	// start listening for any results over the resultsChan
@@ -169,7 +170,8 @@ func getAndPrintTokens(runPodsInfo []RunPodInfo, concurrencyLimit int) {
 
 	// keen an index and loop through every Url we will send a request to
 	for i, podInfo := range runPodsInfo {
-
+		localI := i
+		localPodInfo := podInfo
 		// start a go routine with the index and Url in a closure
 		go func(i int, podInfo RunPodInfo) {
 
@@ -202,7 +204,7 @@ func getAndPrintTokens(runPodsInfo []RunPodInfo, concurrencyLimit int) {
 			// another goroutine to start
 			<-semaphoreChan
 
-		}(i, podInfo)
+		}(localI, localPodInfo)
 	}
 
 	// start listening for any results over the resultsChan


### PR DESCRIPTION
Makefile remove code duplication in make file.

Uses local variables in the goroutines to avoid unwanted race conditions when scanning pods async.