### PR TITLE
Pid2Pod Fix

### DIFF
--- a/cmd/pid2pod/lookuppod.go
+++ b/cmd/pid2pod/lookuppod.go
@@ -46,13 +46,11 @@ func LookupPod(pid int, executable string, podInfo *podList, tw table.Writer) (*
 		for _, status := range item.Status.ContainerStatuses {
 			for _, extractedID := range containerIDs {
 				var runtime string
-				if strings.HasPrefix(status.ContainerID, "docker://") {
-					runtime = "docker"
-				} else if strings.HasPrefix(status.ContainerID, "containerd://") {
+				if strings.Contains(status.ContainerID, "containerd") {
 					runtime = "containerd"
-				} else {
-					fmt.Printf("Unknown runtime for Pod ContainerID: %s\n", status.ContainerID)
-					continue
+				}
+				if strings.Contains(status.ContainerID, "docker") {
+					runtime = "docker"
 				}
 
 				formattedContainerID := fmt.Sprintf("%s://%s", runtime, extractedID)

--- a/cmd/pid2pod/lookuppod.go
+++ b/cmd/pid2pod/lookuppod.go
@@ -1,12 +1,9 @@
 /*
 Copyright (c) 2020 CyberArk Software Ltd. All rights reserved
-
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
-
 	http://www.apache.org/licenses/LICENSE-2.0
-
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -18,10 +15,11 @@ package pid2pod
 import (
 	"bufio"
 	"fmt"
-	"github.com/jedib0t/go-pretty/table"
 	"os"
 	"regexp"
 	"strings"
+
+	"github.com/jedib0t/go-pretty/table"
 )
 
 // ID identifies a single container running in a Kubernetes Pod
@@ -32,32 +30,41 @@ type ID struct {
 	ContainerName string
 }
 
-// LookupPod looks up a process ID from the host PID namespace, returning its Kubernetes identity.
 func LookupPod(pid int, executable string, podInfo *podList, tw table.Writer) (*ID, error) {
-	cid, err := LookupContainerID(pid)
+	containerIDs, err := LookupContainerID(pid)
 	if err != nil {
 		return nil, err
 	}
 
-	var containerRuntime string
+	if len(containerIDs) == 0 {
+		return nil, nil
+	}
+
 	pidAndProcExecutable := fmt.Sprintf("%d (%s)", pid, executable)
+
 	for _, item := range podInfo.Items {
 		for _, status := range item.Status.ContainerStatuses {
-			if strings.Contains(status.ContainerID, "containerd") {
-				containerRuntime = "containerd"
-			}
-			if strings.Contains(status.ContainerID, "docker") {
-				containerRuntime = "docker"
-			}
-			containerID := fmt.Sprintf("%s://%s", containerRuntime, cid)
-			if status.ContainerID == containerID {
-				tw.AppendRow([]interface{}{pidAndProcExecutable, item.Metadata.Name, item.Metadata.Namespace, status.Name})
-				return &ID{
-					Namespace: item.Metadata.Namespace,
-					PodName:   item.Metadata.Name,
-					//ContainerID:   cid,
-					ContainerName: status.Name,
-				}, nil
+			for _, extractedID := range containerIDs {
+				var runtime string
+				if strings.HasPrefix(status.ContainerID, "docker://") {
+					runtime = "docker"
+				} else if strings.HasPrefix(status.ContainerID, "containerd://") {
+					runtime = "containerd"
+				} else {
+					fmt.Printf("Unknown runtime for Pod ContainerID: %s\n", status.ContainerID)
+					continue
+				}
+
+				formattedContainerID := fmt.Sprintf("%s://%s", runtime, extractedID)
+
+				if status.ContainerID == formattedContainerID {
+					tw.AppendRow([]interface{}{pidAndProcExecutable, item.Metadata.Name, item.Metadata.Namespace, status.Name})
+					return &ID{
+						Namespace:     item.Metadata.Namespace,
+						PodName:       item.Metadata.Name,
+						ContainerName: status.Name,
+					}, nil
+				}
 			}
 		}
 	}
@@ -66,25 +73,27 @@ func LookupPod(pid int, executable string, podInfo *podList, tw table.Writer) (*
 
 // LookupContainerID looks up a process ID from the host PID namespace,
 // returning its Docker and Containerd container ID.
-func LookupContainerID(pid int) (string, error) {
+func LookupContainerID(pid int) ([]string, error) {
 	f, err := os.Open(fmt.Sprintf("/proc/%d/cgroup", pid))
 	if err != nil {
-		// this is normal, it just means the PID no longer exists
-		return "", nil
+		return nil, nil // PID might not exist
 	}
 	defer f.Close()
 
+	var containerIDs []string
 	scanner := bufio.NewScanner(f)
 	for scanner.Scan() {
 		line := scanner.Text()
-		parts := kubePattern.FindStringSubmatch(line)
-		if parts != nil {
-			if len(parts) > 1 {
-				return parts[1], nil
+
+		// Extract all matching container IDs from the line
+		matches := kubePattern.FindAllStringSubmatch(line, -1)
+		for _, match := range matches {
+			if len(match) > 1 {
+				containerIDs = append(containerIDs, match[1])
 			}
 		}
 	}
-	return "", nil
+	return containerIDs, nil
 }
 
 var (

--- a/go.mod
+++ b/go.mod
@@ -3,46 +3,42 @@ module kubeletctl
 go 1.19
 
 require (
-	github.com/dgrijalva/jwt-go v3.2.0+incompatible
-	github.com/jedib0t/go-pretty v4.3.0+incompatible
-	github.com/mitchellh/go-ps v1.0.0
-	github.com/spf13/cobra v0.0.7
-	github.com/tidwall/pretty v1.0.1
-	k8s.io/api v0.0.0-20200403220253-fa879b399cd0
-	k8s.io/client-go v0.0.0-20200404181738-fe32aa3b9449
-)
-
-require (
-	github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a // indirect
-	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/docker/spdystream v0.0.0-20160310174837-449fdfce4d96 // indirect
-	github.com/go-openapi/errors v0.19.2 // indirect
-	github.com/go-openapi/strfmt v0.19.5 // indirect
-	github.com/go-stack/stack v1.8.0 // indirect
-	github.com/gogo/protobuf v1.3.1 // indirect
-	github.com/golang/protobuf v1.3.3 // indirect
-	github.com/google/gofuzz v1.1.0 // indirect
-	github.com/imdario/mergo v0.3.5 // indirect
-	github.com/inconshreveable/mousetrap v1.0.0 // indirect
-	github.com/json-iterator/go v1.1.8 // indirect
-	github.com/mattn/go-runewidth v0.0.9 // indirect
-	github.com/mitchellh/mapstructure v1.1.2 // indirect
-	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
-	github.com/modern-go/reflect2 v1.0.1 // indirect
-	github.com/spf13/pflag v1.0.5 // indirect
-	go.mongodb.org/mongo-driver v1.0.3 // indirect
-	golang.org/x/crypto v0.0.0-20200220183623-bac4c82f6975 // indirect
-	golang.org/x/net v0.0.0-20200324143707-d3edc9973b7e // indirect
-	golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45 // indirect
-	golang.org/x/sys v0.7.0 // indirect
-	golang.org/x/text v0.3.2 // indirect
-	golang.org/x/time v0.0.0-20191024005414-555d28b269f0 // indirect
-	google.golang.org/appengine v1.5.0 // indirect
-	gopkg.in/inf.v0 v0.9.1 // indirect
-	gopkg.in/yaml.v2 v2.2.8 // indirect
-	k8s.io/apimachinery v0.0.0-20200403220105-fa0d5bf06730 // indirect
-	k8s.io/klog v1.0.0 // indirect
-	k8s.io/utils v0.0.0-20200324210504-a9aa75ae1b89 // indirect
-	sigs.k8s.io/structured-merge-diff/v3 v3.0.0 // indirect
-	sigs.k8s.io/yaml v1.2.0 // indirect
+        github.com/dgrijalva/jwt-go v3.2.0+incompatible
+        github.com/jedib0t/go-pretty v4.3.0+incompatible
+        github.com/spf13/cobra v0.0.7
+        github.com/tidwall/pretty v1.0.1
+        k8s.io/api v0.0.0-20200403220253-fa879b399cd0
+        k8s.io/client-go v0.0.0-20200404181738-fe32aa3b9449
+        github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a // indirect
+        github.com/davecgh/go-spew v1.1.1 // indirect
+        github.com/docker/spdystream v0.0.0-20160310174837-449fdfce4d96 // indirect
+        github.com/go-openapi/errors v0.19.2 // indirect
+        github.com/go-openapi/strfmt v0.19.5 // indirect
+        github.com/go-stack/stack v1.8.0 // indirect
+        github.com/gogo/protobuf v1.3.1 // indirect
+        github.com/golang/protobuf v1.3.3 // indirect
+        github.com/google/gofuzz v1.1.0 // indirect
+        github.com/imdario/mergo v0.3.5 // indirect
+        github.com/inconshreveable/mousetrap v1.0.0 // indirect
+        github.com/json-iterator/go v1.1.8 // indirect
+        github.com/mattn/go-runewidth v0.0.9 // indirect
+        github.com/mitchellh/mapstructure v1.1.2 // indirect
+        github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
+        github.com/modern-go/reflect2 v1.0.1 // indirect
+        github.com/spf13/pflag v1.0.5 // indirect
+        go.mongodb.org/mongo-driver v1.0.3 // indirect
+        golang.org/x/crypto v0.0.0-20200220183623-bac4c82f6975 // indirect
+        golang.org/x/net v0.0.0-20200324143707-d3edc9973b7e // indirect
+        golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45 // indirect
+        golang.org/x/sys v0.7.0 // indirect
+        golang.org/x/text v0.3.2 // indirect
+        golang.org/x/time v0.0.0-20191024005414-555d28b269f0 // indirect
+        google.golang.org/appengine v1.5.0 // indirect
+        gopkg.in/inf.v0 v0.9.1 // indirect
+        gopkg.in/yaml.v2 v2.2.8 // indirect
+        k8s.io/apimachinery v0.0.0-20200403220105-fa0d5bf06730 // indirect
+        k8s.io/klog v1.0.0 // indirect
+        k8s.io/utils v0.0.0-20200324210504-a9aa75ae1b89 // indirect
+        sigs.k8s.io/structured-merge-diff/v3 v3.0.0 // indirect
+        sigs.k8s.io/yaml v1.2.0 // indirect
 )


### PR DESCRIPTION
I did 2 Changes in the LookUpPod Script cause the execure of ./kubeletctl pid2pod didn't return me the desired outcome.


Change 1:
In the LookupContainerID method.
Change from FindStringSubmatch to FindAllStringSubmatch, this method captures all occurrences of the regex pattern in the text, which is crucial for environments where a process might be associated with multiple containers.

Change 2:
The script assumes there is only one container ID associated with each PID, which might not be accurate in environments where processes can appear in more than one container's.
