### PR TITLE
fix: pretty print error handling

### DIFF
--- a/cmd/print.go
+++ b/cmd/print.go
@@ -53,6 +53,10 @@ func PrintPods(podList v1.PodList) {
 }
 
 func PrintPrettyHttpResponse(resp *http.Response, err error) {
+	if err != nil {
+		log.Fatal(err)
+	}
+
 	bodyBytes, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		log.Fatal(err)


### PR DESCRIPTION
Without this change, the command panics when the http request results in an error.
